### PR TITLE
Update Helsinki Python logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install
 Generate data:
 
 ```
-npm build
+npm run build
 ```
 
 Run development server:

--- a/_data/input.yml
+++ b/_data/input.yml
@@ -62,7 +62,7 @@
     - Python
   url: https://www.meetup.com/helpy-meetups/
   logo: >-
-    https://res.cloudinary.com/toughbyte/image/upload/b_transparent,c_pad,g_center,h_230,w_230/v1445797129/lcc1h6mul4clmqygyhfv.png?_a=BACCd2Ev
+    https://helsinki-python.github.io/logo/HelPy.svg
 - name: Helsinki Ruby Brigade
   location: Helsinki, Finland
   tags:


### PR DESCRIPTION
Also fix data generation command.

I tried changing the URL from https://www.meetup.com/helpy-meetups/ to our general homepage at https://helsinki-python.github.io/ but the whole entry disappeared. I didn't check why.